### PR TITLE
fix(v3-extensions): produce valid x509 v3 CSR and certificates

### DIFF
--- a/create_csr.sh
+++ b/create_csr.sh
@@ -7,8 +7,9 @@ then
 else
 	SUBJECT_ALT_NAME=$1 \
 	openssl req \
+		-config ./openssl.cnf \
 		-newkey rsa -nodes -keyout ./out/${1}.key \
-		-out ./out/${1}.csr -config ./openssl.cnf
+		-out ./out/${1}.csr -extensions v3_req
 
 	chmod 600 ./out/${1}.key
 fi

--- a/sign_csr.sh
+++ b/sign_csr.sh
@@ -16,5 +16,6 @@ else
 	SUBJECT_ALT_NAME=$1 \
 	openssl ca \
 		-out ./out/${1}.crt -config ./openssl.cnf \
-		-notext -infiles ./out/${1}.csr
+		-notext -extensions v3_req \
+		-infiles ./out/${1}.csr
 fi


### PR DESCRIPTION
Add `-extensions` params to CSR and signing scripts to produce valid V3 certificates