### PR TITLE
Parameters upgrade and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,34 @@
-## OpenSSL self-managed Certificate Authority
+# OpenSSL self-managed Certificate Authority
+
+__Notice:__ If you are looking for a way to use SSL certs on public host addresses, please consider using [Let's Encrypt](https://letsencrypt.org/) project! It's free, it's automated and is already trused by common browsers so you won't have to manipulate user's certificates chain of trust. For private addresses (ie: `myhost`, `myhost.mydomain`, `10.0.0.1`, etc) Let's Encrypt won't help you so this project could be very useful.
+
+## Description
 
 Tired of really-complicated-stuff on internet about how to create and maintain self-managed certificates?
-Me too! That's why I've created this simple repo to:
+Me too! That's why I've created this simple project to:
 
-1. Provide sane openssl defaults (sha512/4096 bits keys) via a config file (`openssl.conf`)
+1. Provide sane defaults (`rsa`/`sha256`/`2048` bits keys) via a config file (`openssl.conf`)
 2. Provide a script (`create_ca_key.sh`) to create your own Certificate Authority to sign certificates
 3. Provide a script (`create_csr.sh`) to create keys and certificate signing requests (CSR) for your apps
 4. Provide a script (`sign_csr.sh`) to sign your CSRs
-5. Provide a script (`create_crt.sh`) to make (3) and (4) in one step.
+5. Provide a script (`create_crt.sh`) to perform (3) and (4) in one step.
 
-### Getting started
-1. Clone this repo
-2. Run `create_ca_key.sh` to create your root CA certificate and private key. The root CA certificate will be stored on top directory named `ca.crt`, the private key will be stored in `./private/ca.key`. You should call this script only once, as it will overwrite any existing CA key and CA certificate already present on the repo.
-3. Create and sign as many certificates you want, using `create_crt.sh <app_name>`. The key, CSR and certificate generated will be stored as `<app_name>.<key|csr|crt>` in the `out` directory.
-4. Ready! You can use your app-specific keys and certificates on your apps. If you want to trust these certificates you should add `./CA/ca.crt` onto your local storage of trusted certificates (copying it to `/usr/local/share/ca-certificates/` and running `update-ca-certificates` on Ubuntu, for example). The nice thing is that what you are really doing is to build your own chain of trust, managed by you.
+## Getting started
 
-__Warning__: Adding `ca.crt` to your list of trusted CA means that your PC will trust any certificate signed by `./CA/private/ca.key` . __Keep this key private!!__
+1. __Clone this repo__
+2. __Run `create_ca_key.sh`__ to create your root CA certificate and private key. The root CA certificate will be stored on the `./CA` folder named `ca.crt` and the private key will be stored in `./CA/private/ca.key`. You should call this script only once, as it will overwrite any existing CA key and CA certificate already present on the repo.
+3. __Create and sign as many certificates you want__, using `create_crt.sh <app_name>`. The key, CSR and certificate generated will be stored as `./out/<app_name>.<key|csr|crt>`.
+4. __Ready!__ You can use your app-specific keys and certificates on your apps. If you want to trust these certificates you should add `./CA/ca.crt` onto your local storage of trusted certificates (on Ubuntu this can be done by copying the file to `/usr/local/share/ca-certificates/` and running `update-ca-certificates`). The nice thing is that what you are really doing is to build your own chain of trust, managed by you.
 
-### Being your own CA
-The openssl.conf file manages various defaults for cert creation. I tried to not include insane parameters but you should really look them to check if those match your definition of sanity.
+__Warning__: Adding `ca.crt` to your list of trusted CA means that your PC will trust any certificate signed by `./CA/private/ca.key` .  This could be used to impersonate any website on PCs that trust this cert so __keep this key private!!__ (Ideally offline)
+
+## Being your own CA
+
+The `openssl.conf` file manages various defaults for cert creation. I tried to not include insane parameters but you should really look them to check if those match your definition of sanity.
 
 It is also possible to uncomment the Defaults (under the `req_distinguished_name` section) if you want to save some keystrokes by pre-completing some boring cert fields.
 
-### References:
+## References:
 1. [SSL certs in debian-administration](http://www.debian-administration.org/article/284/Creating_and_Using_a_self_signed__SSL_Certificates_in_debian)
 2. [Installing a SSL cert on Ubuntu](http://askubuntu.com/questions/73287/how-do-i-install-a-root-certificate)
 3. [OpenSSL sample minimal CA app](https://www.openssl.org/docs/apps/ca.html)

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ It is also possible to uncomment the Defaults (under the `req_distinguished_name
 2. [Installing a SSL cert on Ubuntu](http://askubuntu.com/questions/73287/how-do-i-install-a-root-certificate)
 3. [OpenSSL sample minimal CA app](https://www.openssl.org/docs/apps/ca.html)
 4. [OpenSSL Certificate Authority](https://jamielinux.com/docs/openssl-certificate-authority/introduction.html)
+5. [How to setup your own CA with OpenSSL](https://gist.github.com/Soarez/9688998)

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -4,7 +4,7 @@
 # It is possible to tweak verious configurations like
 # extendedKeyUsage params.
 
-HOME                    = .
+HOME = .
 
 
 [ ca ]
@@ -12,87 +12,87 @@ default_ca = CA_default
 
 
 [ CA_default ]
-dir			= .
-serial			= $dir/serial
-database		= $dir/index.txt
-new_certs_dir		= $dir/newcerts
-certificate		= $dir/CA/ca.crt
-private_key		= $dir/CA/private/ca.key
-default_days		= 730
-default_md 		= sha512
-preserve		= no			# keep passed DN ordering
-email_in_dn		= no
-nameopt			= default_ca
-certopt			= default_ca
-policy			= policy_match
+dir              = .
+serial           = $dir/serial
+database         = $dir/index.txt
+new_certs_dir    = $dir/newcerts
+certificate      = $dir/CA/ca.crt
+private_key      = $dir/CA/private/ca.key
+default_days     = 730
+default_md       = sha512
+preserve         = no                     # whether keep DN ordering
+email_in_dn      = no
+nameopt          = default_ca
+certopt          = default_ca
+policy           = policy_match
 
-crlnumber		= $dir/crlnumber	# the current crl number
-crl			= $dir/crl/crl.pem	# The current CRL
-default_crl_days	= 30			# how long before next CRL
+crlnumber        = $dir/crlnumber         # the current crl number
+crl              = $dir/crl/crl.pem       # The current CRL
+default_crl_days = 30                     # how long before next CRL
 
-RANDFILE		= $dir/CA/private/.rand	# private random number file
-copy_extensions		= copy			# Honor extensions requested of us
+RANDFILE         = $dir/CA/private/.rand  # private random number file
+copy_extensions  = copy                   # Honor extensions requested of us
 
 
 [ req ]
-default_bits		= 4096		# Size of keys
-default_keyfile		= key.pem	# name of generated keys
-default_md		= sha512	# message digest algorithm
-string_mask		= utf8only	# permitted characters
-distinguished_name	= req_distinguished_name
-req_extensions		= v3_req
+default_bits       = 4096                 # Size of keys
+default_keyfile    = key.pem              # name of generated keys
+default_md         = sha512               # message digest algorithm
+string_mask        = utf8only             # permitted characters
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
 
 
 [ req_distinguished_name ]
-0.organizationName		= Organization Name (company)
-#organizationalUnitName		= Organizational Unit Name (department, division)
-#emailAddress			= Email Address
-#emailAddress_max		= 40
-localityName			= Locality Name (city, district)
-stateOrProvinceName		= State or Province Name (full name)
-countryName			= Country Name (2 letter code)
-countryName_min			= 2
-countryName_max			= 2
-commonName			= Common Name (hostname, IP, or your name)
-commonName_max			= 64
+0.organizationName      = Organization Name (company)
+#organizationalUnitName = Organizational Unit Name (department, division)
+#emailAddress           = Email Address
+#emailAddress_max       = 40
+localityName            = Locality Name (city, district)
+stateOrProvinceName     = State or Province Name (full name)
+countryName             = Country Name (2 letter code)
+countryName_min         = 2
+countryName_max         = 2
+commonName              = Common Name (hostname, IP, or your name)
+commonName_max          = 64
 
 # Defaults:
-#0.organizationName_default	= Default ON
-#organizationalUnitName_default	= Default UN
-#localityName_default		= Default LN
-#stateOrProvinceName_default	= Default PN
-#countryName_default		= Default CN
-#emailAddress_default		= Default EA
-commonName_default		= ${ENV::SUBJECT_ALT_NAME}
+#0.organizationName_default     = Default ON
+#organizationalUnitName_default = Default UN
+#localityName_default           = Default LN
+#stateOrProvinceName_default    = Default PN
+#countryName_default            = Default CN
+#emailAddress_default           = Default EA
+commonName_default              = ${ENV::SUBJECT_ALT_NAME}
 
 
 [ v3_req ]
-basicConstraints	= critical,CA:FALSE
-subjectKeyIdentifier	= hash
-keyUsage		= nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment
-extendedKeyUsage	= critical,serverAuth, clientAuth
-subjectAltName		= critical,DNS:${ENV::SUBJECT_ALT_NAME},DNS:www.${ENV::SUBJECT_ALT_NAME},email:move
+basicConstraints     = critical,CA:FALSE
+subjectKeyIdentifier = hash
+keyUsage             = nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment
+extendedKeyUsage     = critical,serverAuth, clientAuth
+subjectAltName       = critical,DNS:${ENV::SUBJECT_ALT_NAME},DNS:www.${ENV::SUBJECT_ALT_NAME},email:move
 
 
 [ v3_ca ]
-basicConstraints	= critical,CA:TRUE
-subjectKeyIdentifier	= hash
-authorityKeyIdentifier	= keyid:always,issuer:always
-keyUsage		= cRLSign, keyCertSign
-issuerAltName		= issuer:copy
-subjectAltName		= critical,DNS:${ENV::SUBJECT_ALT_NAME},email:move
+basicConstraints       = critical,CA:TRUE
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+keyUsage               = cRLSign, keyCertSign
+issuerAltName          = issuer:copy
+subjectAltName         = critical,DNS:${ENV::SUBJECT_ALT_NAME},email:move
 
 
 [ policy_match ]
-countryName		= match
-stateOrProvinceName	= match
-organizationName	= match
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName            = match
+stateOrProvinceName    = match
+organizationName       = match
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
 
 
-[ crl_ext ]		# CRL extensions.
-issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always,issuer:always
+[ crl_ext ]    # CRL extensions.
+issuerAltName          = issuer:copy
+authorityKeyIdentifier = keyid:always,issuer:always
 

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -35,9 +35,9 @@ copy_extensions  = copy                   # Honor extensions requested of us
 
 
 [ req ]
-default_bits       = 4096                 # Size of keys
+default_bits       = 2048                 # Size of keys
 default_keyfile    = key.pem              # name of generated keys
-default_md         = sha512               # message digest algorithm
+default_md         = sha256               # message digest algorithm
 string_mask        = utf8only             # permitted characters
 distinguished_name = req_distinguished_name
 req_extensions     = v3_req


### PR DESCRIPTION
- Update key size from 4096 to 2048 bits
  - Rationale: 2048 bit keys are considered secure at the time of this writing so is a safe default.
- Update hash function to `sha256`
  - Rationale: It is the same algorithm (`sha2`) and I'm more worried about someone breaking it than to someone producing a machine capable of computing 2^256 computations in a reasonable time.
- Cleanup style on `openssl.cnf`
- Updates `README.md` 